### PR TITLE
Disable explicit interpreter test

### DIFF
--- a/tests/set-interpreter-long.sh
+++ b/tests/set-interpreter-long.sh
@@ -28,7 +28,7 @@ echo "running with new interpreter..."
 ln -s "$oldInterpreter" "$newInterpreter"
 ${SCRATCH}/simple
 
-# Skip this test until we solve upstream issue #167
+# Skip this test until we solve upstream issue NixOS#167
 #if test "$(uname)" = Linux; then
 #    echo "running with explicit interpreter..."
 #    "$oldInterpreter" ${SCRATCH}/simple

--- a/tests/set-interpreter-long.sh
+++ b/tests/set-interpreter-long.sh
@@ -28,7 +28,8 @@ echo "running with new interpreter..."
 ln -s "$oldInterpreter" "$newInterpreter"
 ${SCRATCH}/simple
 
-if test "$(uname)" = Linux; then
-    echo "running with explicit interpreter..."
-    "$oldInterpreter" ${SCRATCH}/simple
-fi
+# Skip this test until we solve upstream issue #167
+#if test "$(uname)" = Linux; then
+#    echo "running with explicit interpreter..."
+#    "$oldInterpreter" ${SCRATCH}/simple
+#fi


### PR DESCRIPTION
Running an executable using an explicit interpreter after setting a
long interpreter currently crashes on s390x. This is being tracked on
upstream issue #167. We can enable this test again after this issue
is solved.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>